### PR TITLE
Change codecove action version

### DIFF
--- a/.github/workflows/CPU_Beltrami_build_run.yml
+++ b/.github/workflows/CPU_Beltrami_build_run.yml
@@ -38,7 +38,7 @@ jobs:
 
     - name: Upload coverage reports to Codecov
       if: matrix.dockerfile == 'Dockerfile.coverage'
-      uses: codecov/codecov-action@v4.0.1
+      uses: codecov/codecov-action@v3
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: coverage.info


### PR DESCRIPTION
This PR changes the codecov action version to the same one used in MICM, and gets rid of many warning output in the action log.